### PR TITLE
Added a setter to modify apiKey and appKey

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,3 +28,9 @@ func NewClient(apiKey, appKey string) *Client {
 		HttpClient: http.DefaultClient,
 	}
 }
+
+// SetKeys changes the value of apiKey and appKey.
+func (c *Client) SetKeys(apiKey, appKey string) {
+	c.apiKey = apiKey
+	c.appKey = appKey
+}


### PR DESCRIPTION
In some cases, for saving ressources and re-using object, one might
want to re-use an existing client to perform requests with a different
apiKey/appKey. The SetKeys method allows this.

Related to: https://github.com/DataDog/dd-go/pull/1477
