### PR TITLE
Add Ability to Set Endpoints for Datadog

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import "net/http"
 // Client is the object that handles talking to the Datadog API. This maintains
 // state information for a particular application connection.
 type Client struct {
-	apiKey, appKey string
+	apiKey, appKey, endpoint string
 
 	//The Http Client that is used to make requests
 	HttpClient *http.Client
@@ -27,6 +27,12 @@ func NewClient(apiKey, appKey string) *Client {
 		appKey:     appKey,
 		HttpClient: http.DefaultClient,
 	}
+}
+
+// SetEndpoint sets the API URL. Defaults to null, which will then fallback
+// to the environment variable `"DATADOG_HOST"`.
+func (c *Client) SetEndpoint(endpoint string) {
+	c.endpoint = endpoint
 }
 
 // SetKeys changes the value of apiKey and appKey.

--- a/request.go
+++ b/request.go
@@ -26,9 +26,12 @@ import (
 // uriForAPI is to be called with something like "/v1/events" and it will give
 // the proper request URI to be posted to.
 func (self *Client) uriForAPI(api string) string {
-	url := os.Getenv("DATADOG_HOST")
+	url := self.endpoint
 	if url == "" {
-		url = "https://app.datadoghq.com"
+		url := os.Getenv("DATADOG_HOST")
+		if url == "" {
+			url = "https://app.datadoghq.com"
+		}
 	}
 	if strings.Index(api, "?") > -1 {
 		return url + "/api" + api + "&api_key=" +


### PR DESCRIPTION
Used for configuring the client to talk to different endpoints without having to set an environment variable. 