### PR TITLE
Add MonitorId and MonitorTags to Downtimes

### DIFF
--- a/downtimes.go
+++ b/downtimes.go
@@ -21,15 +21,17 @@ type Recurrence struct {
 }
 
 type Downtime struct {
-	Active     bool        `json:"active,omitempty"`
-	Canceled   int         `json:"canceled,omitempty"`
-	Disabled   bool        `json:"disabled,omitempty"`
-	End        int         `json:"end,omitempty"`
-	Id         int         `json:"id,omitempty"`
-	Message    string      `json:"message,omitempty"`
-	Recurrence *Recurrence `json:"recurrence,omitempty"`
-	Scope      []string    `json:"scope,omitempty"`
-	Start      int         `json:"start,omitempty"`
+	Active      bool        `json:"active,omitempty"`
+	Canceled    int         `json:"canceled,omitempty"`
+	Disabled    bool        `json:"disabled,omitempty"`
+	End         int         `json:"end,omitempty"`
+	Id          int         `json:"id,omitempty"`
+	MonitorId   int         `json:"monitor_id,omitempty"`
+	MonitorTags []string    `json:"monitor_tags,omitempty"`
+	Message     string      `json:"message,omitempty"`
+	Recurrence  *Recurrence `json:"recurrence,omitempty"`
+	Scope       []string    `json:"scope,omitempty"`
+	Start       int         `json:"start,omitempty"`
 }
 
 // reqDowntimes retrieves a slice of all Downtimes.


### PR DESCRIPTION
Add monitor_id and monitor_tag to downtimes for better scoping 